### PR TITLE
Get tomcat to wait for oracle-xe to start

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,8 +252,8 @@ firewall-cmd --zone=public --remove-service=tomcat
 Tomcat is located in `/usr/share/tomcat/`. Tomcat can be controlled by:
 
 ```bash
-systemctl stop tomcat\@oxar
-systemctl start tomcat\@oxar
+systemctl stop tomcat@oxar
+systemctl start tomcat@oxar
 ```
 
 ## Shell Access for Vagrant

--- a/README.md
+++ b/README.md
@@ -252,8 +252,8 @@ firewall-cmd --zone=public --remove-service=tomcat
 Tomcat is located in `/usr/share/tomcat/`. Tomcat can be controlled by:
 
 ```bash
-systemctl stop tomcat
-systemctl start tomcat
+systemctl stop tomcat\@oxar
+systemctl start tomcat\@oxar
 ```
 
 ## Shell Access for Vagrant

--- a/docs/ords_administration.md
+++ b/docs/ords_administration.md
@@ -25,7 +25,7 @@ vi /etc/ords/defaults.xml
 After you have finished updating the file, you will need to re-deploy ORDS. This is achieved by restarting tomcat with the following command.
 
 ```bash
-systemctl restart tomcat\@oxar
+systemctl restart tomcat@oxar
 ```
 
 ## On the command line

--- a/docs/ords_administration.md
+++ b/docs/ords_administration.md
@@ -25,7 +25,7 @@ vi /etc/ords/defaults.xml
 After you have finished updating the file, you will need to re-deploy ORDS. This is achieved by restarting tomcat with the following command.
 
 ```bash
-systemctl restart tomcat
+systemctl restart tomcat\@oxar
 ```
 
 ## On the command line

--- a/docs/ords_upgrade.md
+++ b/docs/ords_upgrade.md
@@ -3,7 +3,7 @@
 To upgrade ORDS, you need to grab the latest copy of ORDS onto your server. Before starting the upgrade, it won't be a bad idea to stop Tomcat.
 
 ```bash
-sudo systemctl stop tomcat\@oxar
+sudo systemctl stop tomcat@oxar
 ```
 
 Now, assuming the version you wish to upgrade to is 3.0.4.60.12.48, and you have downloaded the file `ords.3.0.4.60.12.48.zip` onto your server, you first need to extract the files.

--- a/docs/ords_upgrade.md
+++ b/docs/ords_upgrade.md
@@ -78,5 +78,5 @@ Once, that upgrade process completes, you need to move `ords.war` to the Tomcat 
 
 ```bash
 sudo cp ords.war /usr/share/tomcat/webapps/
-sudo systemctl start tomcat\@oxar
+sudo systemctl start tomcat@oxar
 ```

--- a/docs/ords_upgrade.md
+++ b/docs/ords_upgrade.md
@@ -3,7 +3,7 @@
 To upgrade ORDS, you need to grab the latest copy of ORDS onto your server. Before starting the upgrade, it won't be a bad idea to stop Tomcat.
 
 ```bash
-sudo systemctl stop tomcat
+sudo systemctl stop tomcat\@oxar
 ```
 
 Now, assuming the version you wish to upgrade to is 3.0.4.60.12.48, and you have downloaded the file `ords.3.0.4.60.12.48.zip` onto your server, you first need to extract the files.
@@ -78,5 +78,5 @@ Once, that upgrade process completes, you need to move `ords.war` to the Tomcat 
 
 ```bash
 sudo cp ords.war /usr/share/tomcat/webapps/
-sudo systemctl start tomcat
+sudo systemctl start tomcat\@oxar
 ```

--- a/scripts/tomcat.sh
+++ b/scripts/tomcat.sh
@@ -1,12 +1,20 @@
 #!/bin/bash
 
+TOMCAT_OXAR_SERVICE_NAME=tomcat@oxar
+
 if [ -n "$(command -v yum)" ]; then
     yum install tomcat tomcat-admin-webapps -y
 
     # Set tomcat environmental variables such as CATALINA_HOME
     . /etc/tomcat/tomcat.conf
-    TOMCAT_SERVICE_NAME=tomcat
     TOMCAT_USER=tomcat
+    TOMCAT_SERVICE_NAME=tomcat
+    
+    #Modifications to tomcat service file. Recommendation is to make a copy of the `@`
+    #version. So making a copy and naming it oxar. 
+    cp /usr/lib/systemd/system/tomcat\@.service /usr/lib/systemd/system/${TOMCAT_OXAR_SERVICE_NAME}.service
+    sed -i 's/After=syslog.target network.target/After=syslog.target network.target oracle-xe.service/' /usr/lib/systemd/system/${TOMCAT_OXAR_SERVICE_NAME}.service
+    
 
 elif [ -n "$(command -v apt-get)" ]; then
 
@@ -15,6 +23,7 @@ elif [ -n "$(command -v apt-get)" ]; then
     CATALINA_HOME=/var/lib/tomcat7
     TOMCAT_SERVICE_NAME=tomcat7
     TOMCAT_USER=tomcat7
+    
 else
 
     echo; echo \* No known package manager found \* >&2

--- a/scripts/tomcat.sh
+++ b/scripts/tomcat.sh
@@ -12,9 +12,10 @@ if [ -n "$(command -v yum)" ]; then
     
     #Modifications to tomcat service file. Recommendation is to make a copy of the `@`
     #version. So making a copy and naming it oxar. 
-    cp /usr/lib/systemd/system/tomcat\@.service /usr/lib/systemd/system/${TOMCAT_OXAR_SERVICE_NAME}.service
+    cp /usr/lib/systemd/system/${TOMCAT_SERVICE_NAME}.service /usr/lib/systemd/system/${TOMCAT_OXAR_SERVICE_NAME}.service
     sed -i 's/After=syslog.target network.target/After=syslog.target network.target oracle-xe.service/' /usr/lib/systemd/system/${TOMCAT_OXAR_SERVICE_NAME}.service
-    
+    #Reload systemd just in case anything is cached with this service name
+    systemctl daemon-reload
 
 elif [ -n "$(command -v apt-get)" ]; then
 
@@ -30,7 +31,9 @@ else
     exit 1
 fi
 
+#Stop and dissable tomcat from sytem startup
 systemctl stop ${TOMCAT_SERVICE_NAME}
+systemctl disable ${TOMCAT_SERVICE_NAME}
 
 #Add a user into tomcat-users.xml (/etc/tomcat/tomcat-user.xml) as defined in config.properties
 perl -i -p -e "s/<tomcat-users>/<tomcat-users>\n  <\!-- Auto generated content by http\:\/\/www.github.com\/OraOpenSource\/oraclexe-apex install scripts -->\n  <role rolename=\"manager-gui\"\/>\n  <user username=\"${OOS_TOMCAT_USERNAME}\" password=\"${OOS_TOMCAT_PASSWORD}\" roles=\"manager-gui\"\/>\n  <\!-- End auto-generated content -->/g" ${CATALINA_HOME}/conf/tomcat-users.xml
@@ -43,5 +46,5 @@ cp -f ${CATALINA_HOME}/conf/server.xml ${CATALINA_HOME}/conf/server_original.xml
 # Set the preferred port
 sed -i "s/OOS_TOMCAT_SERVER_PORT/${OOS_TOMCAT_PORT}/" ${CATALINA_HOME}/conf/server.xml
 
-systemctl enable ${TOMCAT_SERVICE_NAME}
-systemctl start ${TOMCAT_SERVICE_NAME}
+systemctl enable ${TOMCAT_OXAR_SERVICE_NAME}
+systemctl start ${TOMCAT_OXAR_SERVICE_NAME}

--- a/scripts/tomcat.sh
+++ b/scripts/tomcat.sh
@@ -14,7 +14,7 @@ if [ -n "$(command -v yum)" ]; then
     #version. So making a copy and naming it oxar. 
     #Add `oracle-xe` to the After clause to encourage waiting for the db to be up and running
     cp /usr/lib/systemd/system/${TOMCAT_SERVICE_NAME}.service /usr/lib/systemd/system/${TOMCAT_OXAR_SERVICE_NAME}.service
-    sed -i 's/After=syslog.target network.target/After=syslog.target network.target oracle-xe.service/' /usr/lib/systemd/system/${TOMCAT_OXAR_SERVICE_NAME}.service
+    sed -i 's/After=syslog.target network.target/After=syslog.target network.target oracle-e.service/' /usr/lib/systemd/system/${TOMCAT_OXAR_SERVICE_NAME}.service
     
 
 elif [ -n "$(command -v apt-get)" ]; then
@@ -32,7 +32,10 @@ elif [ -n "$(command -v apt-get)" ]; then
     #https://wiki.debian.org/LSBInitScripts
     #See also https://refspecs.linuxbase.org/LSB_3.0.0/LSB-PDA/LSB-PDA/facilname.html
     sed -i 's/# Should-Start:      \$named/# Should-Start:      \$named oracle-xe/' /etc/init.d/${TOMCAT_OXAR_SERVICE_NAME}
+    #Also replace the script executable path
     sed -i 's/\/etc\/init\.d\/tomcat7/\/etc\/init.d\/tomcat@oxar/' /etc/init.d/${TOMCAT_OXAR_SERVICE_NAME}
+    #and the provides name to match script name
+    sed -i 's/Provides:          tomcat7/Provides:          tomcat@oxar/' /etc/init.d/${TOMCAT_OXAR_SERVICE_NAME}
     
 else
 

--- a/scripts/tomcat.sh
+++ b/scripts/tomcat.sh
@@ -14,7 +14,7 @@ if [ -n "$(command -v yum)" ]; then
     #version. So making a copy and naming it oxar. 
     #Add `oracle-xe` to the After clause to encourage waiting for the db to be up and running
     cp /usr/lib/systemd/system/${TOMCAT_SERVICE_NAME}.service /usr/lib/systemd/system/${TOMCAT_OXAR_SERVICE_NAME}.service
-    sed -i 's/After=syslog.target network.target/After=syslog.target network.target oracle-e.service/' /usr/lib/systemd/system/${TOMCAT_OXAR_SERVICE_NAME}.service
+    sed -i 's/After=syslog.target network.target/After=syslog.target network.target oracle-xe.service/' /usr/lib/systemd/system/${TOMCAT_OXAR_SERVICE_NAME}.service
     
 
 elif [ -n "$(command -v apt-get)" ]; then

--- a/scripts/tomcat.sh
+++ b/scripts/tomcat.sh
@@ -29,6 +29,7 @@ elif [ -n "$(command -v apt-get)" ]; then
     #as Red Hat counter part (it uses a service file rather than init script).
     cp /etc/init.d/${TOMCAT_SERVICE_NAME} /etc/init.d/${TOMCAT_OXAR_SERVICE_NAME}
     #According to https://wiki.debian.org/LSBInitScripts, the `Should-Start` clause
+    #should wait for specified services to start if available.
     #https://wiki.debian.org/LSBInitScripts
     #See also https://refspecs.linuxbase.org/LSB_3.0.0/LSB-PDA/LSB-PDA/facilname.html
     sed -i 's/# Should-Start:      \$named/# Should-Start:      \$named oracle-xe/' /etc/init.d/${TOMCAT_OXAR_SERVICE_NAME}


### PR DESCRIPTION
Closes #165.

* Make a copy of the tomcat service named `tomcat@oxar`.
* Add `oracle-xe` to the `After` property in the unit definition (RH)
* Add `oracle-xe` to the `Should-Start` property in the init script (D).  
(As I understand, these should encourage tomcat to wait until Orace has started before starting)
* Update docs with new service name